### PR TITLE
Update to 1.6

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -20,6 +20,20 @@
     <screenshot>https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/4.png</screenshot>
   </screenshots>
   <releases>
+    <release version="1.6" date="2018-05-26">
+      <description>
+        <ul>
+          <li>OpenGL backend now properly multithreaded, giving a good speed boost.</li>
+          <li>Various Vulkan performance improvements and memory allocation fixes.</li>
+          <li>GPU command interpreter performance improvements</li>
+          <li>Bugfixes and some performance improvements in the ARM64 JIT compiler and IR interpreter</li>
+          <li>Shader cache enabled for Vulkan</li>
+          <li>Texture replacement ID bugfix (note: some textures from 1.5.4 may become incompatible)</li>
+          <li>Adhoc multiplayer fixes</li>
+          <li>Vulkan support on Linux/SDL</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5.4" date="2017-12-05"/>
     <release version="1.5.1" date="2017-11-29">
       <description>

--- a/appdata.xml
+++ b/appdata.xml
@@ -20,6 +20,11 @@
     <screenshot>https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/4.png</screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.1" date="2018-05-30">
+      <description>
+        <p>Fix various crashes</p>
+      </description>
+    </release>
     <release version="1.6" date="2018-05-26">
       <description>
         <ul>

--- a/appdata.xml
+++ b/appdata.xml
@@ -20,6 +20,7 @@
     <screenshot>https://raw.githubusercontent.com/flathub/org.ppsspp.PPSSPP/master/screenshots/4.png</screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.3" date="2018-06-05"/>
     <release version="1.6.1" date="2018-05-30">
       <description>
         <p>Fix various crashes</p>

--- a/org.ppsspp.PPSSPP.json
+++ b/org.ppsspp.PPSSPP.json
@@ -57,7 +57,7 @@
         {
           "type": "git",
           "url": "https://github.com/hrydgard/ppsspp.git",
-          "tag": "v1.5.4",
+          "tag": "v1.6",
           "disable-shallow-clone": true
         },
         {

--- a/org.ppsspp.PPSSPP.json
+++ b/org.ppsspp.PPSSPP.json
@@ -21,19 +21,19 @@
     "shared-modules/glew/glew.json",
     {
       "name": "libzip",
-      "config-opts": ["--disable-static"],
+      "buildsystem": "cmake-ninja",
+      "config-opts": ["-DCMAKE_BUILD_TYPE=Release"],
       "cleanup": [
         "/bin",
         "/include",
         "/lib/pkgconfig",
-        "/share/man",
-        "/lib/*.la"
+        "/share/man"
       ],
       "sources": [
         {
           "type": "archive",
-          "url": "https://libzip.org/download/libzip-1.3.2.tar.xz",
-          "sha256": "6277845010dbc20e281a77e637c97765c1323d67df4d456fd942f525ea86e185"
+          "url": "https://libzip.org/download/libzip-1.5.1.tar.xz",
+          "sha256": "04ea35b6956c7b3453f1ed3f3fe40e3ddae1f43931089124579e8384e79ed372"
         }
       ]
     },
@@ -57,7 +57,7 @@
         {
           "type": "git",
           "url": "https://github.com/hrydgard/ppsspp.git",
-          "tag": "v1.6.1",
+          "tag": "v1.6.3",
           "disable-shallow-clone": true
         },
         {

--- a/org.ppsspp.PPSSPP.json
+++ b/org.ppsspp.PPSSPP.json
@@ -57,7 +57,7 @@
         {
           "type": "git",
           "url": "https://github.com/hrydgard/ppsspp.git",
-          "tag": "v1.6",
+          "tag": "v1.6.1",
           "disable-shallow-clone": true
         },
         {


### PR DESCRIPTION
Currently broken with Nvidia at least:

```
I: VulkanLoader.cpp:290: Vulkan test instance created successfully.
I: VulkanLoader.cpp:324: Found working Vulkan API!
Vulkan might be available.
```

Then it just crashes..

EDIT: And of course it doesn't crash under `gdb`!