### PR TITLE
Fix aarch64 build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "skip-arches": ["arm", "aarch64"]
+  "skip-arches": ["arm"]
 }

--- a/org.ppsspp.PPSSPP.json
+++ b/org.ppsspp.PPSSPP.json
@@ -61,6 +61,14 @@
         },
         {
           "type": "file",
+          "path": "rebuild_ffmpeg.sh"
+        },
+        {
+          "type": "shell",
+          "commands": ["./rebuild_ffmpeg.sh"]
+        },
+        {
+          "type": "file",
           "path": "ppsspp.desktop"
         },
         {

--- a/org.ppsspp.PPSSPP.json
+++ b/org.ppsspp.PPSSPP.json
@@ -15,6 +15,9 @@
     "--socket=x11",
     "--share=network"
   ],
+  "cleanup": [
+    "/ffmpeg"
+  ],
   "modules": [
     "shared-modules/glu/glu-9.json",
     "shared-modules/glew/glew.json",
@@ -37,12 +40,44 @@
       ]
     },
     {
+      "name": "ppsspp-ffmpeg",
+      "buildsystem": "simple",
+      "build-commands": [
+        "rm -r ./linux",
+        "./build.sh",
+        "mkdir -p /app/ffmpeg && cp -r ./linux /app/ffmpeg/"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/hrydgard/ppsspp-ffmpeg.git",
+          "commit": "55147e5f33f5ae4904f75ec082af809267122b94"
+        },
+        {
+          "type": "script",
+          "dest-filename": "build.sh",
+          "only-arches": ["aarch64"],
+          "commands":[
+            "sed -i 's/GENERAL=/GENERAL_NO=/' linux_arm64.sh",
+            "./linux_arm64.sh"
+          ]
+        },
+        {
+          "type": "script",
+          "dest-filename": "build.sh",
+          "only-arches": ["x86_64"],
+          "commands":["./linux_x86-64.sh"]
+        }
+      ]
+    },
+    {
       "name": "ppsspp",
       "buildsystem": "cmake-ninja",
       "no-make-install": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-        "-DOpenGL_GL_PREFERENCE=GLVND"
+        "-DOpenGL_GL_PREFERENCE=GLVND",
+	"-DUSING_GLES2=ON"
       ],
       "build-commands": [
         "mkdir -p /app/ppsspp /app/bin /app/share/applications",
@@ -60,12 +95,11 @@
           "commit": "087de849bdc74205dd00d8e6e11ba17a591213ab"
         },
         {
-          "type": "file",
-          "path": "rebuild_ffmpeg.sh"
-        },
-        {
           "type": "shell",
-          "commands": ["./rebuild_ffmpeg.sh"]
+          "commands": [
+            "rm -r ffmpeg/linux",
+            "ln -s /app/ffmpeg/linux ffmpeg/linux"
+          ]
         },
         {
           "type": "file",

--- a/rebuild_ffmpeg.sh
+++ b/rebuild_ffmpeg.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ "$FLATPAK_ARCH" == "aarch64" ];then
+	cd ffmpeg
+	# GENERAL is used to set cross compile option, rename it to disable it.
+	sed "s/GENERAL=/GENERAL_NO=/;" linux_arm64.sh > linux_arm64_no_cross.sh
+	chmod +x linux_arm64_no_cross.sh
+	./linux_arm64_no_cross.sh
+fi

--- a/rebuild_ffmpeg.sh
+++ b/rebuild_ffmpeg.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-if [ "$FLATPAK_ARCH" == "aarch64" ];then
-	cd ffmpeg
-	# GENERAL is used to set cross compile option, rename it to disable it.
-	sed "s/GENERAL=/GENERAL_NO=/;" linux_arm64.sh > linux_arm64_no_cross.sh
-	chmod +x linux_arm64_no_cross.sh
-	./linux_arm64_no_cross.sh
-fi


### PR DESCRIPTION
The aarch64 build failed as a link error on ffmpeg.  
The ppsspp use a precompiled ffmpeg at [ppsspp-ffmepg](https://github.com/hrydgard/ppsspp-ffmpeg).   
It seems that the precompiled build at ffmpeg/linux/aarch64 is too old to be linked.   
As the hrydgard(author) said that use system ffmpeg is a bad idea, so need to recompile ffmpeg.   