### PR TITLE
Move USING_GLES2 option to aarch64 only

### DIFF
--- a/org.ppsspp.PPSSPP.json
+++ b/org.ppsspp.PPSSPP.json
@@ -76,9 +76,15 @@
       "no-make-install": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-        "-DOpenGL_GL_PREFERENCE=GLVND",
-	"-DUSING_GLES2=ON"
+        "-DOpenGL_GL_PREFERENCE=GLVND"
       ],
+      "build-options": {
+        "arch":{
+          "aarch64": {
+            "config-opts": ["-DUSING_GLES2=ON"]
+          }
+        }
+      },
       "build-commands": [
         "mkdir -p /app/ppsspp /app/bin /app/share/applications",
         "install -m755 PPSSPPSDL /app/ppsspp/",


### PR DESCRIPTION
Sorry for this pr, as I forget to drop the option used for my device.  
This option will force use opengles not opengl.
As the [conformant-products-opengles](https://www.khronos.org/conformance/adopters/conformant-products/opengles), all most all armv8(aarch64) devices support openges 2+, and few supports opengl 4.5+.  
So set it for aarch64 now, as no dynamically load support.
