### PR TITLE
Fix Discord interoperability

### DIFF
--- a/org.ppsspp.PPSSPP.yml
+++ b/org.ppsspp.PPSSPP.yml
@@ -8,6 +8,7 @@ command: PPSSPPSDL
 finish-args:
   - --device=all
   - --filesystem=host:ro
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland


### PR DESCRIPTION
I think this may fix #25, although I have no way of testing it. But @fighuass can do a simple test on the current build with `flatpak run --filesystem=xdg-run/app/com.discordapp.Discord:create org.ppsspp.PPSSPP`.

Alternatively, you may try:
`flatpak run --socket=fallback-x11 org.ppsspp.PPSSPP`

@fighuass Please report what, if anything, works for you.