### PR TITLE
Grant access to Gamescope socket for Steam Deck

### DIFF
--- a/org.ppsspp.PPSSPP.yml
+++ b/org.ppsspp.PPSSPP.yml
@@ -17,8 +17,6 @@ finish-args:
   - --env=SDL_VIDEO_X11_WMCLASS=org.ppsspp.PPSSPP
   - --env=SDL_VIDEO_WAYLAND_WMCLASS=org.ppsspp.PPSSPP
   # required for Gamescope on Steam Deck
-  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
-  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
   - --filesystem=xdg-run/gamescope-0:ro
 modules:
   - shared-modules/glu/glu-9.json

--- a/org.ppsspp.PPSSPP.yml
+++ b/org.ppsspp.PPSSPP.yml
@@ -16,6 +16,10 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --env=SDL_VIDEO_X11_WMCLASS=org.ppsspp.PPSSPP
   - --env=SDL_VIDEO_WAYLAND_WMCLASS=org.ppsspp.PPSSPP
+  # required for Gamescope on Steam Deck
+  - --env=PATH=/app/bin:/app/utils/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
+  - --env=LD_LIBRARY_PATH=/usr/lib/extensions/vulkan/gamescope/lib
+  - --filesystem=xdg-run/gamescope-0:ro
 modules:
   - shared-modules/glu/glu-9.json
   - shared-modules/glew/glew.json


### PR DESCRIPTION
I encounter this error every time I launch a PPSSPP game through Steam Deck's Game Mode UI:
![20240120_180303](https://github.com/flathub/org.DolphinEmu.dolphin-emu/assets/99134546/5a4b3ca1-99ae-41e2-9af8-6d2591799d27)

I've encountered it many times before when launching games through other Flatpaks, like those for Lutris, Heroic, and other emulators. Recently, I found that this error went away after adding support for HDR on Steam Deck to [Lutris Flatpak](https://github.com/flathub/net.lutris.Lutris/commit/3ec57b415882054d06668911aaa73761dfd47d14) -- itself based on the method used for enabling HDR support on [Heroic](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/issues/3281#issuecomment-1886180726) and [Chiaki4deck](https://github.com/streetpea/chiaki4deck/issues/93#issuecomment-1830897848).

Similar to PRs I have made for [RetroArch](https://github.com/flathub/org.libretro.RetroArch/pull/278), [Dolphin](https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178), and [PrimeHack](https://github.com/flathub/io.github.shiiion.primehack/pull/28), I have tested and confirmed that just adding the gamescope-0 socket is enough to make the error go away, with no apparent regressions, if you have the Gamescope Flatpak installed:
```bash
flatpak install flathub org.freedesktop.Platform.VulkanLayer.gamescope
```