### PR TITLE
Add missing touch control support in manifest

### DIFF
--- a/org.ppsspp.PPSSPP.metainfo.xml
+++ b/org.ppsspp.PPSSPP.metainfo.xml
@@ -370,6 +370,7 @@
     <control>pointing</control>
     <control>keyboard</control>
     <control>gamepad</control>
+    <control>touch</control>
   </supports>
   <content_rating type="oars-1.1"/>
   <keywords>


### PR DESCRIPTION
PPSSPP has confirmed working touch based input on a Pinephone Pro running Mobian.